### PR TITLE
Daemon option for tftp

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,20 +1,27 @@
 class tftp::config {
-  file {'/etc/xinetd.d/tftp':
-    content => template('tftp/xinetd-tftp'),
-    mode    => '0644',
-    require => [Class['tftp::install'], Class['xinetd::install']],
-    notify  => Class['xinetd::service']
-  }
-  file {'/etc/tftpd.map':
-    content => template('tftp/tftpd.map'),
-    mode    => '0644',
-    require => [Class['tftp::install'], Class['xinetd::install']],
-    notify  => Class['xinetd::service']
-  }
 
+  case $tftp::params::daemon {
+    true: { } # not needed for daemon-mode
+    false: {
+      include xinetd
+      file {'/etc/xinetd.d/tftp':
+        content => template('tftp/xinetd-tftp'),
+        mode    => '0644',
+        require => [Class['tftp::install'], Class['xinetd::install']],
+        notify  => Class['xinetd::service']
+      }
 
-  file { $tftp::params::root:
-    ensure => directory,
-    notify => Class['xinetd::service'],
+      file {'/etc/tftpd.map':
+        content => template('tftp/tftpd.map'),
+        mode    => '0644',
+        require => [Class['tftp::install'], Class['xinetd::install']],
+        notify  => Class['xinetd::service']
+      }
+
+      file { $tftp::params::root:
+        ensure => directory,
+        notify => Class['xinetd::service'],
+      }
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,6 @@
 class tftp {
-  include xinetd
   include tftp::params
   include tftp::install
   include tftp::config
+  include tftp::service
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,7 +4,7 @@ class tftp::install {
       $tftp_package = 'tftp-server'
     }
     Debian: {
-      $tftp_package = 'atftpd'
+      $tftp_package = 'tftpd-hpa'
     }
     default: {
       fail("${::hostname}: This module does not support operatingsystem ${::operatingsystem}")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,3 +1,13 @@
 class tftp::params {
-  $root = '/tftpboot'
+  case $::operatingsystem {
+    Debian: {
+      $root    = "/srv/tftp"
+      $daemon  = true
+      $service = 'tftpd-hpa'
+    }
+    default: {
+      $root   = '/tftpboot'
+      $daemon = false
+    }
+  }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,0 +1,15 @@
+class tftp::service {
+
+  # No service needed if not daemonized
+  case $tftp::params::daemon {
+    false: { }
+    true: {
+      service { "$tftp::params::service":
+        ensure    => running,
+        enable    => true,
+        alias     => "tftpd",
+        subscribe => Class['tftp::config'],
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is aimed at Debian/Ubuntu. I find TFTP more reliable as a daemon than an inetd service, and I prefer the tftpd-hpa package. This patch changes the pacakage, and defaults to daemon mode for Debian/Ubuntu. It should not affect Redhat at all

I'll merge this tomorrow night if nobody objects, as impact should be minimal
