### PR TITLE
Add class relationships to tftp and lint-check

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,4 +3,9 @@ class tftp {
   include tftp::install
   include tftp::config
   include tftp::service
+
+  Class['tftp::params']~>
+  Class['tftp::install']~>
+  Class['tftp::config']~>
+  Class['tftp::service']
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,7 +6,7 @@ class tftp::params {
       $service = 'tftpd-hpa'
     }
     Ubuntu: {
-      $root    = "/var/lib/tftpboot/"
+      $root    = '/var/lib/tftpboot/'
       $daemon  = true
       $service = 'tftpd-hpa'
     }


### PR DESCRIPTION
Prevents annoying ordering bugs. Would like to use 'class' declarations instead of 'include' but we can't (we use 'include' in the proxy manifests). I'll tidy that up later - for now the explicit Class relationships fix the problem
