### PR TITLE
Fix TFTP location on newer RHEL/Fedora releases

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,9 +10,13 @@ class tftp::params {
       $daemon  = true
       $service = 'tftpd-hpa'
     }
-    default: {
-      $root   = '/tftpboot'
-      $daemon = false
+    RedHat, CentOS, Fedora, Scientific: {
+      if $::operatingsystemrelease =~ /^(4|5)/ {
+        $root  = '/tftpboot/'
+      } else {
+        $root  = '/var/lib/tftpboot/'
+      }
+      $daemon  = false
     }
   }
 }


### PR DESCRIPTION
Moved to /var/lib/tftpboot on Fedora and RHEL 6+
