### PR TITLE
Switch to puppetlabs-xinetd

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,23 +4,28 @@ class tftp::config {
     default: { } # not needed for daemon-mode
     false: {
       include xinetd
-      file {'/etc/xinetd.d/tftp':
-        content => template('tftp/xinetd-tftp'),
-        mode    => '0644',
-        require => Class['tftp::install', 'xinetd::install'],
-        notify  => Class['xinetd::service']
-      }
+
+       xinetd::service { 'tftp':
+         port        => '69',
+         server      => '/usr/sbin/in.tftpd',
+         server_args => "-v -s ${tftp::params::root} -m /etc/tftpd.map",
+         socket_type => 'dgram',
+         protocol    => 'udp',
+         cps         => '100 2',
+         flags       => 'IPv4',
+         per_source  => '11',
+       }
 
       file {'/etc/tftpd.map':
         content => template('tftp/tftpd.map'),
         mode    => '0644',
-        require => Class['tftp::install', 'xinetd::install'],
-        notify  => Class['xinetd::service']
+        require => Class['tftp::install'],
+        notify  => Class['xinetd']
       }
 
       file { $tftp::params::root:
         ensure => directory,
-        notify => Class['xinetd::service'],
+        notify => Class['xinetd'],
       }
     }
   }


### PR DESCRIPTION
This one is a little complex because in parallel to merging this it needs someone to drop the existing xinetd submodule and clone over the puppetlabs-xinetd one to theforeman's account.

Here is the output of /etc/xinetd.d/tftp on a run with the changes and new xinetd module:

[root@localhost foreman-installer]# cat /etc/xinetd.d/tftp 
# This file is being maintained by Puppet.
# DO NOT EDIT

service tftp
{
        port            = 69
        disable         = no
        socket_type     = dgram
        protocol        = udp
        wait            = yes
        user            = root
        group           = root
        server          = /usr/sbin/in.tftpd
        bind            = 0.0.0.0
        server_args     = -v -s /var/lib/tftpboot/ -m /etc/tftpd.map
        per_source      = 11

```
    cps             = 100 2
    flags           = IPv4
```

}
