### PR TITLE
fixes #2342 keeping $oslevel, setting warning to $osfamily

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,13 +1,13 @@
 class tftp::install {
-  case $::operatingsystem {
-    redhat,centos,fedora,Scientific: {
+  case $::osfamily {
+    RedHat: {
       $tftp_package = 'tftp-server'
     }
-    Debian,Ubuntu: {
+    Debian: {
       $tftp_package = 'tftpd-hpa'
     }
     default: {
-      fail("${::hostname}: This module does not support operatingsystem ${::operatingsystem}")
+      fail("${::hostname}: This module does not support operatingsystem ${::osfamily}")
     }
   }
 


### PR DESCRIPTION
removed the checks for every redhat variant, set the check to ::osfamily,  removed the double check for Ubunto under the Debian check and also changed the not supported from ::operatingsystem to ::osfamily.  This should allow all RedHat based OS's including Oracle Linux to install with latest facter showing the correct ::osfamily.
