### PR TITLE
Add Amazon support + clean up

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,18 @@ class tftp::params {
         $root  = '/var/lib/tftpboot/'
       }
     }
+    Linux: {
+      case $::operatingsystem {
+        Amazon: {
+          $package = 'tftp-server'
+          $daemon  = false
+          $root    = '/var/lib/tftpboot/'
+        }
+        default: {
+          fail("${::hostname}: This module does not support operatingsystem ${::operatingsystem}")
+        }
+      }
+    }
     default: {
       fail("${::hostname}: This module does not support osfamily ${::osfamily}")
     }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -89,6 +89,70 @@ describe 'tftp' do
     end
   end
 
+  context 'on Amazon Linux' do
+    let :facts do
+      {
+        :operatingsystem => 'Amazon',
+        :osfamily        => 'Linux',
+      }
+    end
+
+    it 'should include classes' do
+      should contain_class('tftp::install')
+      should contain_class('tftp::config')
+      should contain_class('tftp::service')
+    end
+
+    it 'should install packages' do
+      should contain_package('tftp-server').with({
+        :ensure => 'installed',
+        :alias  => 'tftp-server',
+      })
+      should contain_package('syslinux').with_ensure('installed')
+    end
+
+    it 'should configure xinetd' do
+      should contain_class('xinetd')
+
+      should contain_xinetd__service('tftp').with({
+        :port        => '69',
+        :server      => '/usr/sbin/in.tftpd',
+        :server_args => '-v -s /var/lib/tftpboot/ -m /etc/tftpd.map',
+        :socket_type => 'dgram',
+        :protocol    => 'udp',
+        :cps         => '100 2',
+        :flags       => 'IPv4',
+        :per_source  => '11',
+      })
+
+      should contain_file('/etc/tftpd.map').
+        with_content(%r{^# Convert backslashes to slashes}).
+        with_mode('0644')
+
+      should contain_file('/var/lib/tftpboot/').with({
+        :ensure => 'directory',
+        :notify => 'Class[Xinetd]',
+      })
+    end
+
+    it 'should not contain the service' do
+      should_not contain_service('tftpd-hpa')
+    end
+  end
+
+  context 'on unsupported Linux operatingsystem' do
+    let :facts do
+      {
+        :operatingsystem => 'unsupported',
+        :osfamily        => 'Linux',
+      }
+    end
+
+    it 'should fail' do
+      expect { subject }.to raise_error(Puppet::Error, /: This module does not support operatingsystem #{facts[:operatingsystem]}/)
+    end
+  end
+
   context 'on unsupported osfamily' do
     let :facts do
       {:osfamily => 'unsupported'}


### PR DESCRIPTION
Similar to https://github.com/theforeman/puppet-foreman/pull/113 it's split in
a clean up and a patch to add Amazon Linux support. This supersedes
https://github.com/theforeman/puppet-tftp/pull/12.
