### PR TITLE
syslinux package got split-up in Debian/jessie

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,7 +5,7 @@ class tftp::install {
     alias  => 'tftp-server'
   }
 
-  package {'syslinux':
+  package { $tftp::params::syslinux_package:
     ensure => installed
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,10 +10,16 @@ class tftp::params {
       } else {
         $root = '/srv/tftp'
       }
+      if $::operatingsystemrelease =~ /^8/ {
+        $syslinux_package = [ 'syslinux-common', 'pxelinux' ]
+      } else {
+        $syslinux_package = 'syslinux'
+      }
     }
     RedHat: {
-      $package = 'tftp-server'
-      $daemon  = false
+      $package          = 'tftp-server'
+      $daemon           = false
+      $syslinux_package = 'syslinux'
       if $::operatingsystemrelease =~ /^(4|5)/ {
         $root  = '/tftpboot/'
       } else {
@@ -23,9 +29,10 @@ class tftp::params {
     Linux: {
       case $::operatingsystem {
         Amazon: {
-          $package = 'tftp-server'
-          $daemon  = false
-          $root    = '/var/lib/tftpboot/'
+          $package          = 'tftp-server'
+          $daemon           = false
+          $root             = '/var/lib/tftpboot/'
+          $syslinux_package = 'syslinux'
         }
         default: {
           fail("${::hostname}: This module does not support operatingsystem ${::operatingsystem}")

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -91,6 +91,21 @@ describe 'tftp' do
     end
   end
 
+  context 'on Debian/jessie' do
+    let :facts do
+      {
+        :osfamily              => 'Debian',
+        :operatingsystem       => 'Debian',
+        :operatingsystemrelease => '8.0'
+      }
+    end
+
+    it 'should install Debian/jessie specific packages' do
+      should contain_package('pxelinux').with_ensure('installed')
+      should contain_package('syslinux-common').with_ensure('installed')
+    end
+  end
+
   context 'on Amazon Linux' do
     let :facts do
       {


### PR DESCRIPTION
pxelinux.0 is in ```pxelinux``` now, menu.c32 and chain.c32 are in ```syslinux-common``` now:
https://packages.debian.org/jessie/amd64/pxelinux/filelist
https://packages.debian.org/jessie/amd64/syslinux-common/filelist