### PR TITLE
fixes #9034 - validate tftp root parameter is an absolute path

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,9 @@
 class tftp (
   $root = $tftp::params::root,
 ) inherits tftp::params {
+
+  validate_absolute_path($root)
+
   class {'tftp::install':} ->
   class {'tftp::config':} ~>
   class {'tftp::service':} ->


### PR DESCRIPTION
Adds validation suggested in [PR 25](https://github.com/theforeman/puppet-tftp/pull/25) by @ekohl.