### PR TITLE
Enable param docs lint check on main class

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,0 +1,4 @@
+---
+Rakefile:
+  param_docs_pattern:
+    - manifests/init.pp

--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ PuppetLint.configuration.log_format = '%{path}:%{linenumber}:%{KIND}: %{message}
 
 require 'puppet-lint-param-docs/tasks'
 PuppetLintParamDocs.define_selective do |config|
-  config.pattern = []
+  config.pattern = ['manifests/init.pp']
 end
 
 task :default => [:validate, :lint, :spec]


### PR DESCRIPTION
Not used by kafo, but there's no harm in starting a positive trend!