### PR TITLE
Set service provider to systemd on Ubuntu 16.04 (Xenial)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,12 @@ class tftp::params {
       $package = 'tftpd-hpa'
       $daemon  = true
       $service = 'tftpd-hpa'
+      if $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') >= 0 {
+        # 16.04's Puppet package defaults to upstart (https://bugs.launchpad.net/ubuntu/+source/puppet/+bug/1570472)
+        $service_provider = 'systemd'
+      } else {
+        $service_provider = undef
+      }
       if $::operatingsystem == 'Ubuntu' {
         $root = '/var/lib/tftpboot'
       } else {
@@ -44,6 +50,7 @@ class tftp::params {
       $package = 'tftp-hpa'
       $daemon  = true
       $service = 'tftpd'
+      $service_provider = undef
       $root = '/tftpboot'
       $syslinux_package = 'syslinux'
     }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -9,6 +9,7 @@ class tftp::service {
         ensure    => running,
         enable    => true,
         alias     => 'tftpd',
+        provider  => $::tftp::params::service_provider,
         subscribe => Class['tftp::config'],
       }
     }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -94,6 +94,10 @@ describe 'tftp' do
             :subscribe => 'Class[Tftp::Config]',
           })
         end
+
+        if facts[:operatingsystem] == 'Ubuntu' && facts[:operatingsystemrelease] == '16.04'
+          it { should contain_service('tftpd-hpa').with_provider('systemd') }
+        end
       end
 
       context 'with root set to /changed' do


### PR DESCRIPTION
Works around a bug in the OS Puppet package where the systemd provider
is not set as the default, causing:

    Tftp::Service/Service[tftpd-hpa]: Could not evaluate: Execution of
    '/sbin/status tftpd-hpa' returned 1: status: Unable to connect to
    Upstart: Failed to connect to socket /com/ubuntu/upstart:
    Connection refused

(https://bugs.launchpad.net/ubuntu/+source/puppet/+bug/1570472)