### PR TITLE
mark compatible with puppetlabs/xinetd 2.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "puppetlabs/xinetd",
-      "version_requirement": ">= 1.1.0 < 2.0.0"
+      "version_requirement": ">= 1.1.0 < 3.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
According to their changelog, the only backwards incompatible change is that Puppet 2.x is not supported anymore. Tested on CentOS 7.2.