### PR TITLE
Fix missing default parameter for strict variable tests

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -58,6 +58,7 @@ class tftp::params {
       $package          = 'tftp-hpa'
       $daemon           = true
       $service          = 'tftpd.socket' #systemd starts the socket not the service
+      $service_provider = undef
       $syslinux_package = 'syslinux'
       $root             = '/srv/tftp'
     }


### PR DESCRIPTION
Amazon failures ought to be fixed by https://github.com/puppetlabs/puppetlabs-xinetd/pull/81