### PR TITLE
Fix `invalid byte sequence in UTF-8` error

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -29,9 +29,10 @@ class tftp::config {
       }
 
       file {'/etc/tftpd.map':
-        source => "puppet:///modules/${module_name}/tftpd.map",
-        mode   => '0644',
-        notify => Class['xinetd'],
+        source    => "puppet:///modules/${module_name}/tftpd.map",
+        mode      => '0644',
+        show_diff => false, # Puppet explodes with 'Error: invalid byte sequence in UTF-8' when trying to display the diff
+        notify    => Class['xinetd'],
       }
 
       file { $::tftp::root:


### PR DESCRIPTION
Previously the catalog compiled, but did not apply.  Applying the file
resource would fail with `invalid byte sequence in UTF-8` when trying to
display the diff.