### PR TITLE
Set the service for the Red Hat osfamily

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,4 +1,13 @@
 ---
+.travis.yml:
+  beaker_sets:
+    - docker/centos-6
+    - docker/centos-7
+    - docker/debian-8
 Rakefile:
   param_docs_pattern:
     - manifests/init.pp
+spec/spec_helper_acceptance.rb:
+  modules:
+    - puppetlabs-stdlib
+    - puppetlabs-xinetd

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,24 @@ matrix:
       env: PUPPET_VERSION=4.6 ONLY_OS="debian-8-x86_64,centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,freebsd-10-amd64,windows-2012 R2-x64"
     - rvm: 2.4.1
       env: PUPPET_VERSION=5.0 ONLY_OS="debian-8-x86_64,centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,freebsd-10-amd64,windows-2012 R2-x64"
+    # Acceptance tests
+    - rvm: 2.3.1
+      dist: trusty
+      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/centos-6
+      script: bundle exec rake beaker
+      services: docker
+      bundler_args: --without development
+    - rvm: 2.3.1
+      dist: trusty
+      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/centos-7
+      script: bundle exec rake beaker
+      services: docker
+      bundler_args: --without development
+    - rvm: 2.3.1
+      dist: trusty
+      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/debian-8
+      script: bundle exec rake beaker
+      services: docker
+      bundler_args: --without development
 bundler_args: --without system_tests development
 sudo: false

--- a/data/RedHat.yaml
+++ b/data/RedHat.yaml
@@ -1,5 +1,6 @@
 ---
 tftp::daemon: false
+tftp::service: tftp.socket
 tftp::package: tftp-server
 tftp::root: "/var/lib/tftpboot"
 tftp::syslinux_package: syslinux

--- a/spec/acceptance/tftp_redhat_spec.rb
+++ b/spec/acceptance/tftp_redhat_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper_acceptance'
+
+describe 'tftp with explicit daemon', :if => fact('osfamily') == 'RedHat' && fact('operatingsystemmajrelease') == '7' do
+  before(:all) do
+    on hosts, puppet('resource', 'service', 'xinetd', 'ensure=stopped', 'enable=false')
+    on hosts, puppet('resource', 'service', 'tftp.socket', 'ensure=stopped', 'enable=false')
+  end
+
+  after(:all) do
+    on hosts, puppet('resource', 'service', 'xinetd', 'ensure=stopped', 'enable=false')
+    on hosts, puppet('resource', 'service', 'tftp.socket', 'ensure=stopped', 'enable=false')
+  end
+
+  let(:pp) do
+    <<-EOS
+    class { '::tftp':
+      daemon => true,
+    }
+
+    file { "${::tftp::root}/test":
+      ensure  => file,
+      content => 'clap your hands',
+    }
+    EOS
+  end
+
+  it_behaves_like 'a idempotent resource'
+
+  describe service('xinetd') do
+    it { is_expected.not_to be_enabled }
+    it { is_expected.not_to be_running }
+  end
+
+  describe service('tftp.socket') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  # This doesn't work on Travis - actual tftp testing is more reliable anyway
+  describe port(69), :unless => ENV['TRAVIS'] do
+    it { is_expected.to be_listening.with('udp') }
+  end
+
+  describe 'ensure tftp client is installed' do
+    on hosts, puppet('resource', 'package', 'tftp', 'ensure=installed')
+  end
+
+  describe command("echo get /test /tmp/downloaded_file | tftp #{fact('fqdn')}") do
+    its(:exit_status) { should eq 0 }
+  end
+
+  describe file('/tmp/downloaded_file') do
+    it { should be_file }
+    its(:content) { should eq 'clap your hands' }
+  end
+end

--- a/spec/acceptance/tftp_spec.rb
+++ b/spec/acceptance/tftp_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper_acceptance'
+
+describe 'tftp with default parameters' do
+  before(:all) do
+    on hosts, puppet('resource', 'service', 'xinetd', 'ensure=stopped', 'enable=false')
+  end
+
+  after(:all) do
+    on hosts, puppet('resource', 'service', 'xinetd', 'ensure=stopped', 'enable=false')
+  end
+
+  let(:pp) do
+    <<-EOS
+    class { '::tftp': }
+
+    file { "${::tftp::root}/test":
+      ensure  => file,
+      content => 'do the happy dance',
+    }
+    EOS
+  end
+
+  it_behaves_like 'a idempotent resource'
+
+  service_name = case fact('osfamily')
+                 when 'RedHat'
+                   'xinetd'
+                 when 'Debian'
+                   'tftpd-hpa'
+                 end
+
+  describe service(service_name) do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe port(69) do
+    it { is_expected.to be_listening.with('udp') }
+  end
+
+  describe 'ensure tftp client is installed' do
+    on hosts, puppet('resource', 'package', 'tftp', 'ensure=installed')
+  end
+
+  describe command("echo get /test /tmp/downloaded_file | tftp #{fact('fqdn')}") do
+    its(:exit_status) { should eq 0 }
+  end
+
+  describe file('/tmp/downloaded_file') do
+    it { should be_file }
+    its(:content) { should eq 'do the happy dance' }
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -16,7 +16,7 @@ RSpec.configure do |c|
     # Install module and dependencies
     puppet_module_install(:source => proj_root, :module_name => 'tftp')
     hosts.each do |host|
-      ["puppetlabs-stdlib"].each do |mod|
+      ["puppetlabs-stdlib", "puppetlabs-xinetd"].each do |mod|
         on host, puppet('module', 'install', mod), { :acceptable_exit_codes => [0] }
       end
 


### PR DESCRIPTION
This allows setting $daemon to true on Red Hat systems with systemd. Because the migration is hard we don't flip the value.

Based on https://github.com/theforeman/puppet-tftp/pull/45