### PR TITLE
Remove redundant symlink

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,3 @@ fixtures:
   repositories:
     stdlib: 'git://github.com/puppetlabs/puppetlabs-stdlib'
     xinetd: 'git://github.com/puppetlabs/puppetlabs-xinetd'
-  symlinks:
-    tftp: "#{source_dir}"


### PR DESCRIPTION
With recent versions of puppetlabs_spec_helper this is done automatically