### PR TITLE
Update the supported operating systems

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -3,8 +3,10 @@
   beaker_sets:
     - centos6-64
     - centos7-64
+    - centos8-64
     - debian8-64
     - debian9-64
     - debian10-64
+    - fedora31-64
     - ubuntu1604-64
     - ubuntu1804-64

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,28 @@ matrix:
     - rvm: 2.5.1
       env:
         - BEAKER_PUPPET_COLLECTION=puppet5
+        - BEAKER_setfile=centos8-64{hostname=centos8-64.example.com}
+      script: bundle exec rake beaker
+      services: docker
+      bundler_args: --without development
+      before_install:
+        - echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
+        - sudo service docker restart
+
+    - rvm: 2.5.1
+      env:
+        - BEAKER_PUPPET_COLLECTION=puppet6
+        - BEAKER_setfile=centos8-64{hostname=centos8-64.example.com}
+      script: bundle exec rake beaker
+      services: docker
+      bundler_args: --without development
+      before_install:
+        - echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
+        - sudo service docker restart
+
+    - rvm: 2.5.1
+      env:
+        - BEAKER_PUPPET_COLLECTION=puppet5
         - BEAKER_setfile=debian8-64{hostname=debian8-64.example.com}
       script: bundle exec rake beaker
       services: docker
@@ -112,6 +134,28 @@ matrix:
       env:
         - BEAKER_PUPPET_COLLECTION=puppet6
         - BEAKER_setfile=debian10-64{hostname=debian10-64.example.com}
+      script: bundle exec rake beaker
+      services: docker
+      bundler_args: --without development
+      before_install:
+        - echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
+        - sudo service docker restart
+
+    - rvm: 2.5.1
+      env:
+        - BEAKER_PUPPET_COLLECTION=puppet5
+        - BEAKER_setfile=fedora31-64{hostname=fedora31-64.example.com}
+      script: bundle exec rake beaker
+      services: docker
+      bundler_args: --without development
+      before_install:
+        - echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
+        - sudo service docker restart
+
+    - rvm: 2.5.1
+      env:
+        - BEAKER_PUPPET_COLLECTION=puppet6
+        - BEAKER_setfile=fedora31-64{hostname=fedora31-64.example.com}
       script: bundle exec rake beaker
       services: docker
       bundler_args: --without development

--- a/data/CentOS-6.yaml
+++ b/data/CentOS-6.yaml
@@ -1,3 +1,2 @@
 ---
-tftp::root: "/tftpboot"
 tftp::daemon: false

--- a/data/CentOS-7.yaml
+++ b/data/CentOS-7.yaml
@@ -1,3 +1,2 @@
 ---
-tftp::root: "/tftpboot"
 tftp::daemon: false

--- a/data/Debian-6.yaml
+++ b/data/Debian-6.yaml
@@ -1,2 +1,0 @@
----
-tftp::syslinux_package: syslinux

--- a/data/Debian-7.yaml
+++ b/data/Debian-7.yaml
@@ -1,2 +1,0 @@
----
-tftp::syslinux_package: syslinux

--- a/data/RedHat-4.yaml
+++ b/data/RedHat-4.yaml
@@ -1,2 +1,0 @@
----
-tftp::root: "/tftpboot"

--- a/data/RedHat-6.yaml
+++ b/data/RedHat-6.yaml
@@ -1,3 +1,2 @@
 ---
-tftp::root: "/tftpboot"
 tftp::daemon: false

--- a/data/RedHat-7.yaml
+++ b/data/RedHat-7.yaml
@@ -1,3 +1,2 @@
 ---
-tftp::root: "/tftpboot"
 tftp::daemon: false

--- a/data/RedHat.yaml
+++ b/data/RedHat.yaml
@@ -1,5 +1,5 @@
 ---
-tftp::daemon: false
+tftp::daemon: true
 tftp::service: tftp.socket
 tftp::package: tftp-server
 tftp::root: "/var/lib/tftpboot"

--- a/data/Scientific-6.yaml
+++ b/data/Scientific-6.yaml
@@ -1,3 +1,2 @@
 ---
-tftp::root: "/tftpboot"
 tftp::daemon: false

--- a/data/Scientific-7.yaml
+++ b/data/Scientific-7.yaml
@@ -1,3 +1,2 @@
 ---
-tftp::root: "/tftpboot"
 tftp::daemon: false

--- a/metadata.json
+++ b/metadata.json
@@ -34,14 +34,16 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
@@ -54,7 +56,8 @@
     {
       "operatingsystem": "Fedora",
       "operatingsystemrelease": [
-        "26"
+        "30",
+        "31"
       ]
     },
     {

--- a/spec/acceptance/tftp_spec.rb
+++ b/spec/acceptance/tftp_spec.rb
@@ -24,7 +24,7 @@ describe 'tftp with default parameters' do
 
   service_name = case fact('osfamily')
                  when 'RedHat'
-                   'xinetd'
+                   fact('operatingsystemmajrelease').to_i >= 8 ? 'tftp.socket' : 'xinetd'
                  when 'Debian'
                    'tftpd-hpa'
                  end
@@ -34,7 +34,12 @@ describe 'tftp with default parameters' do
     it { is_expected.to be_running }
   end
 
-  describe port(69) do
+  describe service('xinetd'), if: service_name != 'xinetd' do
+    it { is_expected.not_to be_enabled }
+    it { is_expected.not_to be_running }
+  end
+
+  describe port(69), unless: service_name == 'tftp.socket' do
     it { is_expected.to be_listening.with('udp') }
   end
 


### PR DESCRIPTION
Adds Red Hat 8, CentOS 8, Debian 10, Fedora 30 and 31.

This also changes the default for RH-based distros to use a daemon instead of xinetd while keeping xinetd for EL 6 and 7.