### PR TITLE
configure tftp root folder for RHEL8

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,3 +5,5 @@ fixtures:
       puppet_version: '>= 6.0.0'
     stdlib: 'git://github.com/puppetlabs/puppetlabs-stdlib'
     xinetd: 'git://github.com/puppetlabs/puppetlabs-xinetd'
+    systemd: 'https://github.com/camptocamp/puppet-systemd'
+

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,6 +12,26 @@ class tftp::config {
         changes => "set tftpd_flags '\"-s ${tftp::root}\"'",
       }
     }
+    if $facts['os']['family'] =~ /^(RedHat)$/ {
+      if versioncmp($facts['os']['release']['major'], '8') == 0 {
+        systemd::unit_file { 'tftp.service':
+          content => "
+[Unit]
+Description=Tftp Server
+Requires=tftp.socket
+Documentation=man:in.tftpd
+
+[Service]
+ExecStart=/usr/sbin/in.tftpd -s ${tftp::root}
+StandardInput=socket
+
+[Install]
+Also=tftp.socket
+",
+        }
+      }
+    }
+
   } else {
     include xinetd
 


### PR DESCRIPTION
When daemon true in RedHat family greater then 8, the tftpd service is started with the default root folder.
 
Require: systemd: 'https://github.com/camptocamp/puppet-systemd'
