### PR TITLE
Manage more parameters

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,3 +5,4 @@ fixtures:
       puppet_version: '>= 6.0.0'
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib'
     xinetd: 'https://github.com/puppetlabs/puppetlabs-xinetd'
+    systemd: 'https://github.com/camptocamp/puppet-systemd'

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,5 +3,5 @@ fixtures:
     augeas_core:
       repo: 'https://github.com/puppetlabs/puppetlabs-augeas_core'
       puppet_version: '>= 6.0.0'
-    stdlib: 'git://github.com/puppetlabs/puppetlabs-stdlib'
-    xinetd: 'git://github.com/puppetlabs/puppetlabs-xinetd'
+    stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib'
+    xinetd: 'https://github.com/puppetlabs/puppetlabs-xinetd'

--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -6,3 +6,5 @@ tftp::service: tftpd-hpa
 tftp::syslinux_package:
 - syslinux-common
 - pxelinux
+tftp::username: 'tftp'
+tftp::options: '--secure'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,7 +2,7 @@
 # @api private
 class tftp::config {
   if $tftp::manage_root_dir {
-    ensure_resource('file', $tftp::root, {'ensure' => 'directory'})
+    ensure_resource('file', $tftp::root, { 'ensure' => 'directory' })
   }
 
   if $tftp::daemon {
@@ -26,7 +26,7 @@ class tftp::config {
       per_source  => '11',
     }
 
-    file {'/etc/tftpd.map':
+    file { '/etc/tftpd.map':
       source    => $tftp::map_source,
       mode      => '0644',
       show_diff => false, # Puppet explodes with 'Error: invalid byte sequence in UTF-8' when trying to display the diff

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,6 +22,12 @@ class tftp::config {
           content => template('tftp/tftpd-hpa.erb'),
         }
       }
+      'RedHat': {
+        systemd::dropin_file { 'root-directory':
+          unit    => 'tftp.service',
+          content => epp('tftp/tftp.service-override.epp'),
+        }
+      }
       default: {}
     }
   } else {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -28,7 +28,9 @@ class tftp::config {
     include xinetd
 
     xinetd::service { 'tftp':
-      port        => '69',
+      user        => $tftp::username,
+      bind        => $tftp::address,
+      port        => $tftp::port,
       server      => '/usr/sbin/in.tftpd',
       server_args => "-v -s ${tftp::root} -m /etc/tftpd.map",
       socket_type => 'dgram',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,20 +6,23 @@ class tftp::config {
   }
 
   if $tftp::daemon {
-    if $facts['os']['family'] =~ /^(FreeBSD|DragonFly)$/ {
-      augeas { 'set root directory':
-        context => '/files/etc/rc.conf',
-        changes => "set tftpd_flags '\"-s ${tftp::root}\"'",
+    case $facts['os']['family'] {
+      'FreeBSD', 'DragonFly': {
+        augeas { 'set root directory':
+          context => '/files/etc/rc.conf',
+          changes => "set tftpd_flags '\"-s ${tftp::root}\"'",
+        }
       }
-    }
-    if $facts['osfamily'] == 'Debian' {
-      file { '/etc/default/tftpd-hpa':
-        ensure  => file,
-        owner   => 'root',
-        group   => 'root',
-        mode    => '0644',
-        content => template('tftp/tftpd-hpa.erb'),
+      'Debian': {
+        file { '/etc/default/tftpd-hpa':
+          ensure  => file,
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0644',
+          content => template('tftp/tftpd-hpa.erb'),
+        }
       }
+      default: {}
     }
   } else {
     include xinetd

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,6 +12,15 @@ class tftp::config {
         changes => "set tftpd_flags '\"-s ${tftp::root}\"'",
       }
     }
+    if $facts['osfamily'] == 'Debian' {
+      file { '/etc/default/tftpd-hpa':
+        ensure  => file,
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
+        content => template('tftp/tftpd-hpa.erb'),
+      }
+    }
   } else {
     include xinetd
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,10 @@
 # @param map_source The source URL of the mapping file
 # @param service Name of the TFTP service, when daemon is true
 # @param service_provider Override TFTP service provider, when daemon is true
+# @param username Configures the daemon user
+# @param port Configures the Listen Port
+# @param address Configures the Listen Address, if empty it will listen on IPv4 and IPv6 (only on tftpd-hpa)
+# @param options Configures daemon options
 class tftp (
   Stdlib::Absolutepath $root,
   String $package,
@@ -35,6 +39,10 @@ class tftp (
   String $map_source,
   Optional[String] $service = undef,
   Optional[String] $service_provider = undef,
+  String $username = 'root',
+  Stdlib::Port $port = 69,
+  Optional[String] $address = undef,
+  Optional[String] $options = undef,
 ) {
   contain tftp::install
   contain tftp::config

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,7 +41,7 @@ class tftp (
   Optional[String] $service_provider = undef,
   String $username = 'root',
   Stdlib::Port $port = 69,
-  Optional[String] $address = undef,
+  Optional[Stdlib::IP::Address] $address = undef,
   Optional[String] $options = undef,
 ) {
   contain tftp::install

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -42,7 +42,8 @@ describe 'tftp' do
             should contain_class('xinetd')
 
             should contain_xinetd__service('tftp')
-              .with_port('69')
+              .with_user('root')
+              .with_port(69)
               .with_server('/usr/sbin/in.tftpd')
               .with_server_args('-v -s /var/lib/tftpboot -m /etc/tftpd.map')
               .with_socket_type('dgram')

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -77,6 +77,11 @@ describe 'tftp' do
               .with_alias('tftpd')
               .that_subscribes_to('Class[Tftp::Config]')
           end
+
+          it 'should contain the service override' do
+            should contain_systemd__dropin_file('root-directory')
+              .with_content(%r{^ExecStart=/usr/sbin/in\.tftp -s /var/lib/tftpboot$})
+          end
         end
       when 'FreeBSD'
         it 'should not configure xinetd' do

--- a/templates/tftp.service-override.epp
+++ b/templates/tftp.service-override.epp
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/sbin/in.tftp -s <%= $tftp::root %>

--- a/templates/tftpd-hpa.erb
+++ b/templates/tftpd-hpa.erb
@@ -1,0 +1,6 @@
+# /etc/default/tftpd-hpa
+
+TFTP_USERNAME="<%= scope['tftp::username'] %>"
+TFTP_DIRECTORY="<%= scope['tftp::root'] %>"
+TFTP_ADDRESS="<%= scope['tftp::address'] %>:<%= scope['tftp::port'] %>"
+TFTP_OPTIONS="<%= scope['tftp::options'] %>"


### PR DESCRIPTION
This manages /etc/default/tftp-hpa on Debian since that defines the variables. This allows parameters to actually change them and have effect. For the same reason, on EL a drop in is used to respect the root.

Currently still a bit messy. Also needs more tests.

Replaces https://github.com/theforeman/puppet-tftp/pull/91 (Debian part) and https://github.com/theforeman/puppet-tftp/pull/113 (EL part).