### PR TITLE
.fixtures.yml: Cleanup puppet_version

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,5 @@
 fixtures:
   repositories:
-    augeas_core:
-      repo: 'https://github.com/puppetlabs/puppetlabs-augeas_core'
-      puppet_version: '>= 6.0.0'
+    augeas_core: 'https://github.com/puppetlabs/puppetlabs-augeas_core'
     stdlib: 'git://github.com/puppetlabs/puppetlabs-stdlib'
     xinetd: 'git://github.com/puppetlabs/puppetlabs-xinetd'


### PR DESCRIPTION
This module only supports Puppet 6.15 and newer, so the version
contraint in .fixture.yml isn't required anymore.