### PR TITLE
make syslinux package management optional

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,2 +1,3 @@
 ---
 tftp::manage_root_dir: true
+tftp::manage_syslinux_package: true

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,7 @@
 # @param root Configures the root directory for the TFTP server
 # @param package Name of the TFTP server package
 # @param syslinux_package Name of the syslinux package, essential for pxe boot
+# @param manage_syslinux_package manages the syslinux package, defaults to true
 # @param manage_root_dir manages the root dir, which tftpd will serve, defaults to true
 # @param service Name of the TFTP service, when daemon is true
 # @param service_provider Override TFTP service provider, when daemon is true
@@ -23,6 +24,7 @@ class tftp (
   Stdlib::Absolutepath $root,
   String $package,
   Variant[String, Array[String]] $syslinux_package,
+  Boolean $manage_syslinux_package,
   Boolean $manage_root_dir,
   Optional[String] $service = undef,
   Optional[String] $service_provider = undef,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,7 +6,9 @@ class tftp::install {
     alias  => 'tftp-server',
   }
 
-  package { $tftp::syslinux_package:
-    ensure => installed,
+  if $tftp::manage_syslinux_package {
+    package { $tftp::syslinux_package:
+      ensure => installed,
+    }
   }
 }


### PR DESCRIPTION
when finer control over the syslinux package is required, dedicated puppet modules can be used. given that the tftp and the pxe module would then end up managing the same package, one must not in order for the catalog to compile.
this change make the syslinux package management optional, but keeps the current behaviour for backwards compatibility.