### PR TITLE
Ensure procps-ng is installed on Red Hat.

### DIFF
--- a/data/RedHat.yaml
+++ b/data/RedHat.yaml
@@ -3,3 +3,5 @@ tftp::service: tftp.socket
 tftp::package: tftp-server
 tftp::root: "/var/lib/tftpboot"
 tftp::syslinux_package: syslinux
+tftp::optional_packages:
+  - procps-ng

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,7 @@
 # @param manage_root_dir manages the root dir, which tftpd will serve, defaults to true
 # @param service Name of the TFTP service, when daemon is true
 # @param service_provider Override TFTP service provider, when daemon is true
+# @param optional_packages Any extra packages required.
 class tftp (
   Stdlib::Absolutepath $root,
   String $package,
@@ -28,6 +29,7 @@ class tftp (
   Boolean $manage_root_dir,
   Optional[String] $service = undef,
   Optional[String] $service_provider = undef,
+  Optional[Variant[String, Array[String]]] $optional_packages = undef,
 ) {
   contain tftp::install
   contain tftp::config

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,4 +11,10 @@ class tftp::install {
       ensure => installed,
     }
   }
+
+  if $tftp::optional_packages {
+    package { $tftp::optional_packages:
+      ensure => installed,
+    }
+  }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -49,6 +49,11 @@ describe 'tftp' do
             .with_alias('tftpd')
             .that_subscribes_to('Class[Tftp::Config]')
         end
+
+        it 'should contain the procps-ng package' do
+          should contain_package('procps-ng')
+            .with_ensure('installed')
+        end
       when 'FreeBSD'
         it 'should contain the service' do
           should contain_service('tftpd')


### PR DESCRIPTION
The module expects the `ps` utility to already be installed, but it may not be.

```bash
# puppet apply mymanifest.pp 
Notice: Compiled catalog for 933b1f81aa39 in environment production in 0.03 seconds
Notice: /Stage[main]/Tftp::Install/Package[tftp-server]/ensure: created
Notice: /Stage[main]/Tftp::Install/Package[syslinux]/ensure: created
Error: /Stage[main]/Tftp::Service/Service[tftp.socket]: Could not evaluate: Execution of 'ps -ef' returned 1: Error: Could not execute posix command: No such file or directory - ps
Error: /Stage[main]/Tftp::Service/Service[tftp.socket]: Failed to call refresh: Execution of 'ps -ef' returned 1: Error: Could not execute posix command: No such file or directory - ps
Error: /Stage[main]/Tftp::Service/Service[tftp.socket]: Execution of 'ps -ef' returned 1: Error: Could not execute posix command: No such file or directory - ps
Notice: Applied catalog in 46.46 seconds
```

This adds an `optional_packages` parameter to install and adds `procps-ng` to the `RedHat.yaml` Hiera data.