### PR TITLE
Drop Amazon Linux specifics

### DIFF
--- a/data/Amazon.yaml
+++ b/data/Amazon.yaml
@@ -1,5 +1,0 @@
----
-tftp::package: tftp-server
-tftp::root: "/var/lib/tftpboot"
-tftp::service: tftp.socket
-tftp::syslinux_package: syslinux

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -114,35 +114,4 @@ describe 'tftp' do
       end
     end
   end
-
-  context 'on Amazon Linux' do
-    let :facts do
-      {
-        operatingsystem: 'Amazon',
-        osfamily: 'Linux',
-        os: { name: 'Amazon', family: 'Linux' }
-      }
-    end
-
-    it 'should include classes' do
-      should contain_class('tftp::install')
-      should contain_class('tftp::config')
-      should contain_class('tftp::service')
-    end
-
-    it 'should install packages' do
-      should contain_package('tftp-server')
-        .with_ensure('installed')
-        .with_alias('tftp-server')
-      should contain_package('syslinux').with_ensure('installed')
-    end
-
-    it 'should contain the service' do
-      should contain_service('tftp.socket')
-        .with_ensure('running')
-        .with_enable('true')
-        .with_alias('tftpd')
-        .that_subscribes_to('Class[Tftp::Config]')
-    end
-  end
 end


### PR DESCRIPTION
Some older versions of Amazon Linux were identified by facter as the Linux OS family, but in recent versions it's within the Red Hat OS family again. The data file is the same as RedHat.yaml so this should be safe.