### PR TITLE
Manage options

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,3 +2,4 @@ fixtures:
   repositories:
     augeas_core: 'https://github.com/puppetlabs/puppetlabs-augeas_core'
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib'
+    systemd: 'https://github.com/camptocamp/puppet-systemd'

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,4 +2,4 @@ fixtures:
   repositories:
     augeas_core: 'https://github.com/puppetlabs/puppetlabs-augeas_core'
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib'
-    systemd: 'https://github.com/camptocamp/puppet-systemd'
+    systemd: 'https://github.com/voxpupuli/puppet-systemd'

--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -5,3 +5,5 @@ tftp::service: tftpd-hpa
 tftp::syslinux_package:
 - syslinux-common
 - pxelinux
+tftp::username: 'tftp'
+tftp::options: '--secure'

--- a/data/RedHat.yaml
+++ b/data/RedHat.yaml
@@ -3,3 +3,4 @@ tftp::service: tftp.socket
 tftp::package: tftp-server
 tftp::root: "/var/lib/tftpboot"
 tftp::syslinux_package: syslinux
+tftp::options: '--secure'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,10 +5,28 @@ class tftp::config {
     ensure_resource('file', $tftp::root, { 'ensure' => 'directory' })
   }
 
-  if $facts['os']['family'] =~ /^(FreeBSD|DragonFly)$/ {
-    augeas { 'set root directory':
-      context => '/files/etc/rc.conf',
-      changes => "set tftpd_flags '\"-s ${tftp::root}\"'",
+  case $facts['os']['family'] {
+    'FreeBSD', 'DragonFly': {
+      augeas { 'set root directory':
+        context => '/files/etc/rc.conf',
+        changes => "set tftpd_flags '\"-s ${tftp::root}\"'",
+      }
     }
+    'Debian': {
+      file { '/etc/default/tftpd-hpa':
+        ensure  => file,
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
+        content => template('tftp/tftpd-hpa.erb'),
+      }
+    }
+    'RedHat': {
+      systemd::dropin_file { 'root-directory.conf':
+        unit    => 'tftp.service',
+        content => epp('tftp/tftp.service-override.epp'),
+      }
+    }
+    default: {}
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,7 +18,7 @@ class tftp::config {
         owner   => 'root',
         group   => 'root',
         mode    => '0644',
-        content => template('tftp/tftpd-hpa.erb'),
+        content => epp("${module_name}/tftpd-hpa.epp"),
       }
     }
     'RedHat': {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,9 +22,9 @@ class tftp::config {
       }
     }
     'RedHat': {
-      systemd::dropin_file { 'root-directory.conf':
+      systemd::dropin_file { 'tftp.conf':
         unit    => 'tftp.service',
-        content => epp('tftp/tftp.service-override.epp'),
+        content => epp("${module_name}/tftp.service-override.epp"),
       }
     }
     default: {}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,10 @@
 # @param manage_root_dir manages the root dir, which tftpd will serve, defaults to true
 # @param service Name of the TFTP service, when daemon is true
 # @param service_provider Override TFTP service provider, when daemon is true
+# @param username Configures the daemon user
+# @param port Configures the Listen Port
+# @param address Configures the Listen Address, if empty it will listen on IPv4 and IPv6 (only on tftpd-hpa)
+# @param options Configures daemon options
 class tftp (
   Stdlib::Absolutepath $root,
   String $package,
@@ -28,6 +32,10 @@ class tftp (
   Boolean $manage_root_dir,
   Optional[String] $service = undef,
   Optional[String] $service_provider = undef,
+  String $username = 'root',
+  Stdlib::Port $port = 69,
+  Optional[Stdlib::IP::Address] $address = undef,
+  Optional[String] $options = undef,
 ) {
   contain tftp::install
   contain tftp::config

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,7 +32,7 @@ class tftp (
   Boolean $manage_root_dir,
   Optional[String] $service = undef,
   Optional[String] $service_provider = undef,
-  String $username = 'root',
+  String[1] $username = 'root',
   Stdlib::Port $port = 69,
   Optional[Stdlib::IP::Address] $address = undef,
   Optional[String] $options = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,7 +35,7 @@ class tftp (
   String[1] $username = 'root',
   Stdlib::Port $port = 69,
   Optional[Stdlib::IP::Address] $address = undef,
-  Optional[String] $options = undef,
+  Optional[String[1]] $options = undef,
 ) {
   contain tftp::install
   contain tftp::config

--- a/spec/acceptance/tftp_port_spec.rb
+++ b/spec/acceptance/tftp_port_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper_acceptance'
+
+describe 'tftp with default parameters' do
+  it_behaves_like 'an idempotent resource' do
+    let(:manifest) do
+      <<-EOS
+      class { 'tftp':
+        port => 1234,
+      }
+
+      file { "${tftp::root}/test":
+        ensure  => file,
+        content => 'running on a different port',
+      }
+      EOS
+    end
+  end
+
+  service_name = case fact('osfamily')
+                 when 'Archlinux'
+                   'tftpd.socket'
+                 when 'RedHat'
+                   'tftp.socket'
+                 when 'Debian'
+                   'tftpd-hpa'
+                 end
+
+  describe service(service_name) do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe port(69), unless: service_name.end_with?('.socket') do
+    it { is_expected.not_to be_listening }
+  end
+
+  describe port(1234), unless: service_name.end_with?('.socket') do
+    it { is_expected.to be_listening.with('udp') }
+  end
+
+  describe 'ensure tftp client is installed' do
+    on hosts, puppet('resource', 'package', 'tftp', 'ensure=installed')
+  end
+
+  describe command("echo get /test /tmp/downloaded_file | tftp #{fact('fqdn')} 1234") do
+    its(:exit_status) { should eq 0 }
+  end
+
+  describe file('/tmp/downloaded_file') do
+    it { should be_file }
+    its(:content) { should eq 'running on a different port' }
+  end
+end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -49,6 +49,11 @@ describe 'tftp' do
             .with_alias('tftpd')
             .that_subscribes_to('Class[Tftp::Config]')
         end
+
+        it 'should contain the service override' do
+          should contain_systemd__dropin_file('root-directory.conf')
+            .with_content(%r{^ExecStart=/usr/sbin/in\.tftp -s /var/lib/tftpboot$})
+        end
       when 'FreeBSD'
         it 'should contain the service' do
           should contain_service('tftpd')

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -51,8 +51,8 @@ describe 'tftp' do
         end
 
         it 'should contain the service override' do
-          should contain_systemd__dropin_file('root-directory.conf')
-            .with_content(%r{^ExecStart=/usr/sbin/in\.tftp -s /var/lib/tftpboot$})
+          should contain_systemd__dropin_file('tftp.conf')
+            .with_content(%r{^ExecStart=/usr/sbin/in\.tftp --secure /var/lib/tftpboot$})
         end
       when 'FreeBSD'
         it 'should contain the service' do
@@ -77,6 +77,27 @@ describe 'tftp' do
             .with_enable('true')
             .with_alias('tftpd')
             .that_subscribes_to('Class[Tftp::Config]')
+        end
+      end
+
+      context 'with custom options' do
+        let :params do
+          {
+            options: '--secure --verbose'
+          }
+        end
+
+        case facts[:os]['family']
+        when 'Debian'
+          it 'should configure tftpd-hpa with custom options' do
+            should contain_file('/etc/default/tftpd-hpa')
+              .with_content(%r{^TFTP_OPTIONS="--secure --verbose"$})
+          end
+        when 'RedHat'
+          it 'should contain the service override with custom options' do
+            should contain_systemd__dropin_file('tftp.conf')
+              .with_content(%r{^ExecStart=/usr/sbin/in\.tftp --secure --verbose /var/lib/tftpboot$})
+          end
         end
       end
 

--- a/templates/tftp.service-override.epp
+++ b/templates/tftp.service-override.epp
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/sbin/in.tftp -s <%= $tftp::root %>

--- a/templates/tftp.service-override.epp
+++ b/templates/tftp.service-override.epp
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=/usr/sbin/in.tftp -s <%= $tftp::root %>
+ExecStart=/usr/sbin/in.tftp <%= $tftp::options %> <%= $tftp::root %>

--- a/templates/tftpd-hpa.epp
+++ b/templates/tftpd-hpa.epp
@@ -1,4 +1,5 @@
 # /etc/default/tftpd-hpa
+# This file is managed by Puppet.
 
 TFTP_USERNAME="<%= $tftp::username %>"
 TFTP_DIRECTORY="<%= $tftp::root %>"

--- a/templates/tftpd-hpa.epp
+++ b/templates/tftpd-hpa.epp
@@ -1,0 +1,6 @@
+# /etc/default/tftpd-hpa
+
+TFTP_USERNAME="<%= $tftp::username %>"
+TFTP_DIRECTORY="<%= $tftp::root %>"
+TFTP_ADDRESS="<%= $tftp::address %>:<%= $tftp::port %>"
+TFTP_OPTIONS="<%= $tftp::options %>"

--- a/templates/tftpd-hpa.erb
+++ b/templates/tftpd-hpa.erb
@@ -1,0 +1,6 @@
+# /etc/default/tftpd-hpa
+
+TFTP_USERNAME="<%= scope['tftp::username'] %>"
+TFTP_DIRECTORY="<%= scope['tftp::root'] %>"
+TFTP_ADDRESS="<%= scope['tftp::address'] %>:<%= scope['tftp::port'] %>"
+TFTP_OPTIONS="<%= scope['tftp::options'] %>"

--- a/templates/tftpd-hpa.erb
+++ b/templates/tftpd-hpa.erb
@@ -1,6 +1,0 @@
-# /etc/default/tftpd-hpa
-
-TFTP_USERNAME="<%= scope['tftp::username'] %>"
-TFTP_DIRECTORY="<%= scope['tftp::root'] %>"
-TFTP_ADDRESS="<%= scope['tftp::address'] %>:<%= scope['tftp::port'] %>"
-TFTP_OPTIONS="<%= scope['tftp::options'] %>"


### PR DESCRIPTION
- **More flexibility in configuration**
- **fixtures: update puppet-systemd URL to voxpupuli**
- **convert Debian options file template to EPP**
- **RedHat: add default tftp::options**
- **config: add unit tests for tftp::options**

This PR takes #115 and makes small changes to enable management of tftpd options. See also #153 and #141, but my PR is intended to be small enough to review easily so that we can merge it, then add the other features of those other PRs.
